### PR TITLE
상급 재련 재료 추가

### DIFF
--- a/app/api/getAdvancedRefineData/route.ts
+++ b/app/api/getAdvancedRefineData/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import getDbPromise from "@/app/lib/db";
+
+export async function GET(req: NextRequest) {
+  try {
+    const db = await getDbPromise();
+    const collection = db.collection("advancedRefine");
+    const data = await collection.findOne({}, { projection: { _id: 0 } });
+    return NextResponse.json(data, { status: 200 });
+  } catch (error) {
+    console.error("advancedRefine:", error);
+    return NextResponse.json(
+      { error: "getAdvancedRefineData error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/getMaterialPrice/route.ts
+++ b/app/api/getMaterialPrice/route.ts
@@ -1,12 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getMaterialPrice } from "./getMaterialPrice";
-import clientPromise from "../../lib/db";
+import getDbPromise from "../../lib/db";
 import { WithId } from "mongodb";
 
 export async function GET(req: NextRequest) {
   try {
-    const client = await clientPromise;
-    const db = client.db("loakang");
+    const db = await getDbPromise();
     const collection = db.collection("materials");
 
     // id과 createdAt 제외 가져오기

--- a/app/components/Board/Board.tsx
+++ b/app/components/Board/Board.tsx
@@ -16,8 +16,24 @@ interface CalculationResult {
   armor: MaterialCost;
 }
 
+export interface AdvancedRefine {
+  weapon: {
+    tier3_1: MaterialCost;
+    tier3_2: MaterialCost;
+    tier4_1: MaterialCost;
+    tier4_2: MaterialCost;
+  };
+  armor: {
+    tier3_1: MaterialCost;
+    tier3_2: MaterialCost;
+    tier4_1: MaterialCost;
+    tier4_2: MaterialCost;
+  };
+}
+
 interface BoardProps {
   calculationResult: CalculationResult;
+  advancedRefineData: AdvancedRefine;
   materialsPrice: Record<string, number>;
   owned: Record<string, number>;
   setOwned: React.Dispatch<React.SetStateAction<Record<string, number>>>;
@@ -25,6 +41,7 @@ interface BoardProps {
 
 const Board = ({
   calculationResult,
+  advancedRefineData,
   materialsPrice,
   owned,
   setOwned,
@@ -41,17 +58,36 @@ const Board = ({
     let newCost = 0;
     let newMaterials: Record<string, number> = {};
 
-    if (filter.weapon) {
-      newCost += weapon.cost;
-      newMaterials = { ...newMaterials, ...weapon.materials };
-    }
+    const refineKeys = ["tier3_1", "tier3_2", "tier4_1", "tier4_2"] as const;
 
-    if (filter.armor) {
-      newCost += armor.cost;
-      newMaterials = { ...newMaterials, ...armor.materials };
-    }
+    const addMaterials = (
+      category: "weapon" | "armor",
+      key?: (typeof refineKeys)[number]
+    ) => {
+      if (key) {
+        newCost += advancedRefineData[category][key].cost;
+        newMaterials = {
+          ...newMaterials,
+          ...advancedRefineData[category][key].materials,
+        };
+      } else {
+        newCost += calculationResult[category].cost;
+        newMaterials = {
+          ...newMaterials,
+          ...calculationResult[category].materials,
+        };
+      }
+    };
 
-    // 상재 추가
+    if (filter.weapon) addMaterials("weapon");
+    if (filter.armor) addMaterials("armor");
+
+    refineKeys.forEach(key => {
+      if (filter[key]) {
+        if (filter.weapon) addMaterials("weapon", key);
+        if (filter.armor) addMaterials("armor", key);
+      }
+    });
 
     setCurrent({ cost: newCost, materials: newMaterials });
   }, [filter, weapon, armor]);

--- a/app/components/Filter/Filter.tsx
+++ b/app/components/Filter/Filter.tsx
@@ -45,32 +45,70 @@ const Filter = () => {
         <div className={styles.filterTitle}>상급재련</div>
         <div className={styles.filterItem}>
           <img
-            src={selected.tier3 ? "/button/clicked.svg" : "/button/default.svg"}
-            alt="3티어"
-            onClick={() => toggleSelected("tier3")}
+            src={
+              selected.tier3_1 ? "/button/clicked.svg" : "/button/default.svg"
+            }
+            alt="3티어 1~10"
+            onClick={() => toggleSelected("tier3_1")}
             className={styles.icon}
           />
           <label
-            htmlFor="3tier"
+            htmlFor="3_1"
             className={styles.label}
-            onClick={() => toggleSelected("tier3")}
+            onClick={() => toggleSelected("tier3_1")}
           >
-            3티어
+            3T 1~10
           </label>
         </div>
         <div className={styles.filterItem}>
           <img
-            src={selected.tier4 ? "/button/clicked.svg" : "/button/default.svg"}
-            alt="4티어"
-            onClick={() => toggleSelected("tier4")}
+            src={
+              selected.tier3_2 ? "/button/clicked.svg" : "/button/default.svg"
+            }
+            alt="3티어 11~20"
+            onClick={() => toggleSelected("tier3_2")}
             className={styles.icon}
           />
           <label
-            htmlFor="4tier"
+            htmlFor="3_2"
             className={styles.label}
-            onClick={() => toggleSelected("tier4")}
+            onClick={() => toggleSelected("tier3_2")}
           >
-            4티어
+            3T 11~20
+          </label>
+        </div>
+        <div className={styles.filterItem}>
+          <img
+            src={
+              selected.tier4_1 ? "/button/clicked.svg" : "/button/default.svg"
+            }
+            alt="4T 1~10"
+            onClick={() => toggleSelected("tier4_1")}
+            className={styles.icon}
+          />
+          <label
+            htmlFor="4_1"
+            className={styles.label}
+            onClick={() => toggleSelected("tier4_1")}
+          >
+            4T 1~10
+          </label>
+        </div>
+        <div className={styles.filterItem}>
+          <img
+            src={
+              selected.tier4_2 ? "/button/clicked.svg" : "/button/default.svg"
+            }
+            alt="4T 11~20"
+            onClick={() => toggleSelected("tier4_2")}
+            className={styles.icon}
+          />
+          <label
+            htmlFor="4_2"
+            className={styles.label}
+            onClick={() => toggleSelected("tier4_2")}
+          >
+            4T 11~20
           </label>
         </div>
       </div>

--- a/app/lib/db.ts
+++ b/app/lib/db.ts
@@ -1,21 +1,20 @@
-// app/lib/mongodb.js
-import { MongoClient } from "mongodb";
+import { MongoClient, Db } from "mongodb";
 
 const URI = process.env.DB_URI as string;
 const options = {};
 
-let clientPromise: Promise<MongoClient>;
+let dbPromise: Promise<Db>;
 
 if (!URI) {
   throw new Error("Please add your Mongo URI");
 }
 
-function getClientPromise() {
-  if (!clientPromise) {
+function getDbPromise() {
+  if (!dbPromise) {
     const client = new MongoClient(URI, options);
-    clientPromise = client.connect();
+    dbPromise = client.connect().then(client => client.db("loakang"));
   }
-  return clientPromise;
+  return dbPromise;
 }
 
-export default getClientPromise();
+export default getDbPromise;

--- a/app/lib/store.ts
+++ b/app/lib/store.ts
@@ -9,8 +9,10 @@ const useFilterStore = create<FilterState>(set => ({
   selected: {
     weapon: true,
     armor: true,
-    tier3: false,
-    tier4: false,
+    tier3_1: false,
+    tier3_2: false,
+    tier4_1: false,
+    tier4_2: false,
   },
   toggleSelected: item =>
     set(state => ({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,12 +14,25 @@ export default function Home() {
     target: "",
   });
   const [materials, setMaterials] = useState<Record<string, number>>({});
-
   const [owned, setOwned] = useState<Record<string, number>>({});
   const [calculationResult, setCalculationResult] = useState({
     total: { cost: 0, materials: {} },
     weapon: { cost: 0, materials: {} },
     armor: { cost: 0, materials: {} },
+  });
+  const [advancedRefineData, setAdvancedRefineData] = useState({
+    weapon: {
+      tier3_1: { cost: 0, materials: {} },
+      tier3_2: { cost: 0, materials: {} },
+      tier4_1: { cost: 0, materials: {} },
+      tier4_2: { cost: 0, materials: {} },
+    },
+    armor: {
+      tier3_1: { cost: 0, materials: {} },
+      tier3_2: { cost: 0, materials: {} },
+      tier4_1: { cost: 0, materials: {} },
+      tier4_2: { cost: 0, materials: {} },
+    },
   });
 
   useEffect(() => {
@@ -29,6 +42,14 @@ export default function Home() {
     };
 
     fetchMaterials();
+    const fetchAdvancedRefine = async () => {
+      const res = await fetch("/api/getAdvancedRefineData").then(res =>
+        res.json()
+      );
+      setAdvancedRefineData(res);
+    };
+
+    fetchAdvancedRefine();
   }, []);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -45,6 +66,7 @@ export default function Home() {
       <Input level={level} setLevel={setLevel} onSubmit={handleSubmit} />
       <Board
         calculationResult={calculationResult}
+        advancedRefineData={advancedRefineData}
         materialsPrice={materials}
         owned={owned}
         setOwned={setOwned}


### PR DESCRIPTION
### 1. **`app/api/getAdvancedRefineData/route.ts`**

- **새로운 API 엔드포인트 추가**: `GET` 메서드로 상급 재련 데이터(`advancedRefine`)를 MongoDB에서 조회

### 2. **`app/lib/db.ts`**

- `clientPromise` 제거 후 `getDbPromise` 함수로 통일
- MongoDB 연결 시 `DB` 객체를 직접 반환하도록 변경


### 3. **`app/api/getMaterialPrice/route.ts`**

- DB 연결 로직 개선: `clientPromise` 대신 `getDbPromise`로 변경
- 코드 정리 및 중복 제거


### 4. **`app/components/Filter/Filter.tsx`**

- **필터 항목 확장**: `tier3`와 `tier4`를 세부 단계로 분리 (`tier3_1`, `tier3_2`, `tier4_1`, `tier4_2`)


### 5. **`app/lib/store.ts`**

- **필터 상태 추가**: `tier3_1`, `tier3_2`, `tier4_1`, `tier4_2`

### 6. **`app/page.tsx`**

- `fetchAdvancedRefine`로 데이터를 가져오는 로직 추가
- `advancedRefineData` 상태 추가로 `Board.tsx` 에 넘겨줌

### 7. **`app/components/Board/Board.tsx`**

- **상급 재련 데이터 처리 로직 추가**: `tier3`, `tier4` 관련 데이터를 사용하여 계산
- 필터 상태에 따라 실시간 데이터 갱신
