### PR TITLE
fix/#17: getMaterialPrice 갱신 안됨

### DIFF
--- a/Vercel.json
+++ b/Vercel.json
@@ -1,0 +1,10 @@
+{
+  "routes": [
+    {
+      "src": "/api/(.*)",
+      "headers": {
+        "Cache-Control": "no-store"
+      }
+    }
+  ]
+}

--- a/app/api/getMaterialPrice/route.ts
+++ b/app/api/getMaterialPrice/route.ts
@@ -10,8 +10,7 @@ export async function GET(req: NextRequest) {
 
     // id과 createdAt 제외 가져오기
     let materials: WithId<Document> | Record<string, number> | null =
-      await collection.findOne({}, { projection: { _id: 0, createdAt: 0 } });
-
+      await collection.findOne({}, { projection: { _id: 0 } });
     if (!materials) {
       materials = await getMaterialPrice();
       const materialsWithDate = { ...materials, createdAt: new Date() };
@@ -23,7 +22,10 @@ export async function GET(req: NextRequest) {
     //   { expireAfterSeconds: 7200 }
     // );
 
-    return NextResponse.json(materials, { status: 200 });
+    return NextResponse.json(materials, {
+      status: 200,
+      headers: { "Cache-Control": "no-store" },
+    });
   } catch (error) {
     console.error("Error in GET route:", error);
     return NextResponse.json(

--- a/app/api/getMaterialPrice/route.ts
+++ b/app/api/getMaterialPrice/route.ts
@@ -24,7 +24,7 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.json(materials, {
       status: 200,
-      headers: { "Cache-Control": "no-store" },
+      headers: { "Cache-Control": "no-store", ETag: "" },
     });
   } catch (error) {
     console.error("Error in GET route:", error);

--- a/app/api/getMaterialPrice/route.ts
+++ b/app/api/getMaterialPrice/route.ts
@@ -3,6 +3,8 @@ import { getMaterialPrice } from "./getMaterialPrice";
 import getDbPromise from "../../lib/db";
 import { WithId } from "mongodb";
 
+export const revalidate = 0;
+
 export async function GET(req: NextRequest) {
   try {
     const db = await getDbPromise();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -56,7 +56,6 @@ export default function Home() {
     e.preventDefault();
     if (materials) {
       const res = totalCalculator(level.current, level.target, materials);
-      console.log(res, "result");
       setCalculationResult(res);
     }
   };

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(req: NextRequest) {
+  const url = req.nextUrl;
+
+  if (url.pathname.startsWith("/api/getMaterialPrice")) {
+    const response = NextResponse.next();
+    response.headers.set(
+      "Cache-Control",
+      "no-store, no-cache, must-revalidate, proxy-revalidate"
+    );
+    response.headers.set("Pragma", "no-cache");
+    response.headers.set("Expires", "0");
+    return response;
+  }
+
+  return NextResponse.next();
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "routes": [
+    {
+      "src": "/api/(.*)",
+      "headers": {
+        "Cache-Control": "no-store"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
ISR -> SSR 로 변경

**헤매기**
1. Cache-Control 헤더 설정
2. verce.json 에서 cache 헤더 설정
3. middleware.ts 에서 cache 관련 헤더 전부 설정
4. Etag 지우기

를 해봤지만 response 의 헤더에 항상 `x-vercel-cache: HIT`



